### PR TITLE
drmmode_display: Stop animated cursors from flickering on meson

### DIFF
--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -638,29 +638,18 @@ drmmode_load_cursor_argb(xf86CrtcPtr crtc, CARD32 *image)
 	struct drmmode_crtc_private_rec *drmmode_crtc = crtc->driver_private;
 	struct drmmode_rec *drmmode = drmmode_crtc->drmmode;
 	struct drmmode_cursor_rec *cursor = drmmode->cursor;
-	int visible;
 
 	if (!cursor)
 		return;
-
-	visible = drmmode_crtc->cursor_visible;
-
-	if (visible)
-		drmmode_hide_cursor(crtc);
 
 	d = armsoc_bo_map(cursor->bo);
 	if (!d) {
 		xf86DrvMsg(crtc->scrn->scrnIndex, X_ERROR,
 			"load_cursor_argb map failure\n");
-		if (visible)
-			drmmode_show_cursor_image(crtc, TRUE);
 		return;
 	}
 
 	set_cursor_image(crtc, d, image);
-
-	if (visible)
-		drmmode_show_cursor_image(crtc, TRUE);
 }
 
 static Bool
@@ -824,7 +813,7 @@ drmmode_cursor_init_standard(ScreenPtr pScreen)
 
 	cursor->handle = armsoc_bo_handle(cursor->bo);
 
-	if (!xf86_cursors_init(pScreen, w, h, HARDWARE_CURSOR_ARGB)) {
+	if (!xf86_cursors_init(pScreen, w, h, HARDWARE_CURSOR_ARGB | HARDWARE_CURSOR_UPDATE_UNHIDDEN)) {
 		ERROR_MSG("xf86_cursors_init() failed");
 		if (drmModeRmFB(drmmode->fd, cursor->fb_id))
 			ERROR_MSG("drmModeRmFB() failed");


### PR DESCRIPTION
meson is an atomic driver, meaning that it attempts to set the
cursor image with drmModeSetCursor wait until vblank before
completing. For historical reasons, ARMSOC hides the cursor
before updating the pixels in the buffer, which means that we
hide, wait for vblank, show new image, wait for vblank, leading
to awful flickering of the cursor. This is especially visible
during animated cursors like the spinning beachball when opening
an app.

Remove this code. ... and then realize that Xorg does the same
thing in its HW cursor manipulating code, meaning all that code
before was simply dead. Pass a flag to Xorg to tell it to stop
that. We make great APIs.