### PR TITLE
drmmode_display: Copy over VRefresh to/from kernel modes

### DIFF
--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -178,6 +178,7 @@ drmmode_ConvertFromKMode(ScrnInfoPtr pScrn, drmModeModeInfo *kmode,
 	mode->VSyncEnd = kmode->vsync_end;
 	mode->VTotal = kmode->vtotal;
 	mode->VScan = kmode->vscan;
+	mode->VRefresh = kmode->vrefresh;
 
 	mode->Flags = kmode->flags;
 	mode->name = strdup(kmode->name);
@@ -219,6 +220,7 @@ drmmode_ConvertToKMode(ScrnInfoPtr pScrn, drmModeModeInfo *kmode,
 	kmode->vsync_end = mode->VSyncEnd;
 	kmode->vtotal = mode->VTotal;
 	kmode->vscan = mode->VScan;
+	kmode->vrefresh = xf86ModeVRefresh(mode);
 
 	kmode->flags = mode->Flags;
 	if (mode->name)


### PR DESCRIPTION
Our meson driver wants this information so it can find a fitting mode
for modesetting.