### PR TITLE
drmmode_meson: Specify if allocations are for scanout or textures

### DIFF
--- a/src/drmmode_meson/drmmode_meson.c
+++ b/src/drmmode_meson/drmmode_meson.c
@@ -53,6 +53,11 @@ static int create_custom_gem(int fd, struct armsoc_create_gem *create_gem)
 	create_meson.size = create_gem->height * pitch;
 	create_meson.flags = 0;
 
+	if (create_gem->buf_type == ARMSOC_BO_SCANOUT)
+		create_meson.flags |= DRM_MESON_GEM_CREATE_WITH_UMP_FLAG_SCANOUT;
+	else
+		create_meson.flags |= DRM_MESON_GEM_CREATE_WITH_UMP_FLAG_TEXTURE;
+
 	ret = drmIoctl(fd, DRM_IOCTL_MESON_GEM_CREATE_WITH_UMP, &create_meson);
 	if (ret)
 		return ret;

--- a/src/drmmode_meson/meson_drm.h
+++ b/src/drmmode_meson/meson_drm.h
@@ -36,6 +36,10 @@ struct drm_meson_gem_create_with_ump {
 #define DRM_MESON_GEM_CREATE_WITH_UMP    0x00
 #define DRM_MESON_NUM_IOCTLS             0x01
 
+/* Use flags */
+#define DRM_MESON_GEM_CREATE_WITH_UMP_FLAG_SCANOUT 0x01
+#define DRM_MESON_GEM_CREATE_WITH_UMP_FLAG_TEXTURE 0x02
+
 #define DRM_IOCTL_MESON_GEM_CREATE_WITH_UMP  DRM_IOWR(DRM_COMMAND_BASE + DRM_MESON_GEM_CREATE_WITH_UMP, struct drm_meson_gem_create_with_ump)
 
 #endif


### PR DESCRIPTION
The kernel will return cachable mappings for textures, which allows
for higher performance.

https://github.com/endlessm/eos-shell/issues/4472