### PR TITLE
Initialize X background from plymouth's framebuffer

### DIFF
--- a/src/armsoc_driver.h
+++ b/src/armsoc_driver.h
@@ -203,7 +203,7 @@ Bool drmmode_page_flip(DrawablePtr draw, uint32_t fb_id, void *priv);
 void drmmode_wait_for_event(ScrnInfoPtr pScrn);
 Bool drmmode_cursor_init(ScreenPtr pScreen);
 void drmmode_cursor_fini(ScreenPtr pScreen);
-
+uint32_t drmmode_get_crtc_id(ScrnInfoPtr pScrn);
 
 /**
  * DRI2 functions..

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -861,6 +861,15 @@ void drmmode_cursor_fini(ScreenPtr pScreen)
 	free(cursor);
 }
 
+uint32_t drmmode_get_crtc_id(ScrnInfoPtr pScrn)
+{
+	xf86CrtcConfigPtr config = XF86_CRTC_CONFIG_PTR(pScrn);
+	xf86OutputPtr output = config->output[config->compat_output];
+	xf86CrtcPtr crtc = output->crtc;
+	struct drmmode_crtc_private_rec *drmmode_crtc = crtc->driver_private;
+
+	return drmmode_crtc->crtc_id;
+}
 
 #if 1 == ARMSOC_SUPPORT_GAMMA
 static void


### PR DESCRIPTION
With this patch in place the contents of the DRM scanout buffer
will be initialized by bliting from the plymouth's framebuffer.

The option InitFromFBDev has been removed.

[endlessm/eos-shell#2089]