### PR TITLE
fix all calloc syntax mistakes

### DIFF
--- a/src/armsoc_exa.c
+++ b/src/armsoc_exa.c
@@ -164,8 +164,7 @@ ARMSOCCreatePixmap2(ScreenPtr pScreen, int width, int height,
 		int depth, int usage_hint, int bitsPerPixel,
 		int *new_fb_pitch)
 {
-	struct ARMSOCPixmapPrivRec *priv =
-				calloc(sizeof(struct ARMSOCPixmapPrivRec), 1);
+	struct ARMSOCPixmapPrivRec *priv = calloc(1, sizeof(struct ARMSOCPixmapPrivRec));
 	ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
 	struct ARMSOCRec *pARMSOC = ARMSOCPTR(pScrn);
 

--- a/src/armsoc_exa_null.c
+++ b/src/armsoc_exa_null.c
@@ -107,7 +107,7 @@ FreeScreen(FREE_SCREEN_ARGS_DECL)
 struct ARMSOCEXARec *
 InitNullEXA(ScreenPtr pScreen, ScrnInfoPtr pScrn, int fd)
 {
-	struct ARMSOCNullEXARec *null_exa = calloc(sizeof(*null_exa), 1);
+	struct ARMSOCNullEXARec *null_exa = calloc(1, sizeof(*null_exa));
 	struct ARMSOCEXARec *armsoc_exa;
 	ExaDriverPtr exa;
 

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -337,7 +337,7 @@ drmmode_set_mode_major(xf86CrtcPtr crtc, DisplayModePtr mode,
 	crtc->y = y;
 	crtc->rotation = rotation;
 
-	output_ids = calloc(sizeof(uint32_t), xf86_config->num_output);
+	output_ids = calloc(xf86_config->num_output, sizeof(uint32_t));
 	if (!output_ids) {
 		ERROR_MSG(
 				"memory allocation failed in drmmode_set_mode_major()");
@@ -914,7 +914,7 @@ drmmode_crtc_init(ScrnInfoPtr pScrn, struct drmmode_rec *drmmode, int num)
 	if (crtc == NULL)
 		return;
 
-	drmmode_crtc = xnfcalloc(sizeof(struct drmmode_crtc_private_rec), 1);
+	drmmode_crtc = xnfcalloc(1, sizeof(struct drmmode_crtc_private_rec));
 	drmmode_crtc->crtc_id = drmmode->mode_res->crtcs[num];
 	drmmode_crtc->drmmode = drmmode;
 	drmmode_crtc->last_good_mode = NULL;
@@ -1418,7 +1418,7 @@ drmmode_output_init(ScrnInfoPtr pScrn, struct drmmode_rec *drmmode, int num)
 	if (!connector)
 		goto exit;
 
-	encoders = calloc(sizeof(drmModeEncoderPtr), connector->count_encoders);
+	encoders = calloc(connector->count_encoders, sizeof(drmModeEncoderPtr));
 	if (!encoders)
 		goto free_connector_exit;
 
@@ -1437,7 +1437,7 @@ drmmode_output_init(ScrnInfoPtr pScrn, struct drmmode_rec *drmmode, int num)
 	if (!output)
 		goto free_encoders_exit;
 
-	drmmode_output = calloc(sizeof(struct drmmode_output_priv), 1);
+	drmmode_output = calloc(1, sizeof(struct drmmode_output_priv));
 	if (!drmmode_output) {
 		xf86OutputDestroy(output);
 		goto free_encoders_exit;


### PR DESCRIPTION
The first argument is the member number, the second one is each member's size.
