### PR TITLE
armsoc_exa: Don't wait when we're interrupted by a signal

### DIFF
--- a/src/armsoc_exa.c
+++ b/src/armsoc_exa.c
@@ -476,6 +476,10 @@ ARMSOCPrepareAccess(PixmapPtr pPixmap, int index)
 		item.usage = _LOCK_ACCESS_CPU_WRITE;
 		ioctl(pARMSOC->umplock_fd, LOCK_IOCTL_CREATE, &item);
 		while (ioctl(pARMSOC->umplock_fd, LOCK_IOCTL_PROCESS, &item) < 0) {
+			/* If we were interrupted, try again immediately without sleeping... */
+			if (errno == EINTR)
+				continue;
+
 			if (--max_retries == 0) {
 				ErrorF("giving up on locking bo %d\n", item.secure_id);
 				break;


### PR DESCRIPTION
The umplock driver uses down_interruptible for its semaphore when
protecting its internals. The X server is very signal-heavy: every mouse
move or key press makes us wake up with SIGIO and do a poll. This can
interrupt our syscall with the kernel, and we then sleep for 2ms, which
can have disasterous effects when stacked, from general unresponsiveness
to graphics corruption issues.

Perhaps in the future we'll use down_killable instead of
down_interruptiblle in the umplock driver. For now, just don't usleep
when we get EINTR.

[endlessm/eos-shell#4869]