### PR TITLE
Include xorg-server.h to fix build errors on newest glibc

### DIFF
--- a/src/armsoc_dumb.c
+++ b/src/armsoc_dumb.c
@@ -27,6 +27,8 @@
 #include <errno.h>
 #include <unistd.h>
 
+#include <xorg-server.h>
+
 #include <xf86.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>


### PR DESCRIPTION
Without this the build fails on systems with latest glibc with the
following error:

In file included from /usr/include/string.h:634:0,
                 from /usr/include/xorg/os.h:53,
                 from /usr/include/xorg/misc.h:115,
                 from /usr/include/xorg/xf86str.h:37,
                 from /usr/include/xorg/xf86.h:44,
                 from armsoc_dumb.c:30:
/usr/include/xorg/os.h:579:1: error: expected identifier or ‘(’ before ‘__extension__’
 strndup(const char *str, size_t n);

This is caused by HAVE_STRNDUP not being set (it is set from
xorg-server.h), causing os.h to redefine it.

This became a known issue in other xorg stuff as seen on:

http://lists.opensuse.org/archive/opensuse-commit/2014-11/msg00195.html
https://freedesktop.org/patch/34699/