### PR TITLE
Ignore cache control failure

### DIFF
--- a/src/armsoc_exa.c
+++ b/src/armsoc_exa.c
@@ -503,11 +503,9 @@ ARMSOCPrepareAccess(PixmapPtr pPixmap, int index)
 		gsd.handle = armsoc_bo_handle(priv->bo);
 		gsd.write_domain |= ARMSOC_GEM_DOMAIN_CPU;
 		ret = di->gem_set_domain(pARMSOC->drmFD, gsd);
-		if (ret < 0) {
-			ErrorF("gem_set_domain() failed: GEM handle %u: %s\n",
+		if (ret < 0)
+			DEBUG_MSG("gem_set_domain() failed: GEM handle %u: %s",
 			       gsd.handle, strerror(errno));
-			return FALSE;
-		}
 	}
 
 	return TRUE;


### PR DESCRIPTION
There is a corner case that can result in us attempting to
change the domain of a bo that was allocated as scanout.

This happens when an unredirected window has been doing fullscreen
page flips, hence has suitable scanout buffers used for front and back.
If that window then becomes redirected again, a new pixmap (non-scanout
front buffer) will be allocated in the compCheckRedirect() codepath, but
DRI2's bo cache is left untouched, so it maintains its old, scanout back
buffer.

If the exchangebufs path now happens on this window, we end up with the
new non-scanout front buffer pixmap pointing at the old, scanout back
buffer. And if we're then asked to do CPU access to this pixmap, we'll
end up doing cache control on a scanout bo, so the gem_set_domain call
will fail.

Rather than trying some tricky scheme to detect and correct this
condition, just ignore cache control ioctl failure, like Mali does.

Solves an X abort with Chromium unredirected at fullscreen, when you
press the volume keys, which temporarily places a volume indicator window
on top of Chromium, causing Chromium to become redirected again.

[endlessm/eos-shell#6160]