### PR TITLE
Xserver 1.19 support

### DIFF
--- a/src/compat-api.h
+++ b/src/compat-api.h
@@ -77,7 +77,12 @@
 
 #define SCREEN_INIT_ARGS_DECL ScreenPtr pScreen, int argc, char **argv
 
+#if ABI_VIDEODRV_VERSION >= SET_ABI_VERSION(22,0)
+#define HAVE_NOTIFY_FD	1
+#endif
+
 #if ABI_VIDEODRV_VERSION >= SET_ABI_VERSION(23, 0)
+#define RELOAD_CURSORS_DEPRECATED 1
 #define BLOCKHANDLER_ARGS_DECL \
 	ScreenPtr arg, pointer pTimeout
 #define BLOCKHANDLER_ARGS arg, pTimeout

--- a/src/compat-api.h
+++ b/src/compat-api.h
@@ -77,9 +77,15 @@
 
 #define SCREEN_INIT_ARGS_DECL ScreenPtr pScreen, int argc, char **argv
 
+#if ABI_VIDEODRV_VERSION >= SET_ABI_VERSION(23, 0)
+#define BLOCKHANDLER_ARGS_DECL \
+	ScreenPtr arg, pointer pTimeout
+#define BLOCKHANDLER_ARGS arg, pTimeout
+#else
 #define BLOCKHANDLER_ARGS_DECL \
 	ScreenPtr arg, pointer pTimeout, pointer pReadmask
 #define BLOCKHANDLER_ARGS arg, pTimeout, pReadmask
+#endif
 
 #define CLOSE_SCREEN_ARGS_DECL ScreenPtr pScreen
 #define CLOSE_SCREEN_ARGS pScreen

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -450,9 +450,11 @@ done_setting:
 		drmmode_output_dpms(output, DPMSModeOn);
 	}
 
+#if !RELOAD_CURSORS_DEPRECATED
 	/* if hw cursor is initialized, reload it */
 	if (drmmode->cursor)
 		xf86_reload_cursors(pScrn->pScreen);
+#endif
 
 cleanup:
 	if (newcrtc)
@@ -2038,6 +2040,13 @@ drmmode_uevent_fini(ScrnInfoPtr pScrn)
 	TRACE_EXIT();
 }
 
+#if HAVE_NOTIFY_FD
+static void
+drmmode_notify_fd(int fd, int notify, void *data)
+{
+	drmHandleEvent(fd, &event_context);
+}
+#else
 static void
 drmmode_wakeup_handler(pointer data, int err, pointer p)
 {
@@ -2053,6 +2062,7 @@ drmmode_wakeup_handler(pointer data, int err, pointer p)
 	if (FD_ISSET(drmmode->fd, read_mask))
 		drmHandleEvent(drmmode->fd, &event_context);
 }
+#endif
 
 void
 drmmode_wait_for_event(ScrnInfoPtr pScrn)
@@ -2068,15 +2078,29 @@ drmmode_screen_init(ScrnInfoPtr pScrn)
 
 	drmmode_uevent_init(pScrn);
 
+#if HAVE_NOTIFY_FD
+	SetNotifyFd(drmmode->fd, drmmode_notify_fd, X_NOTIFY_READ, NULL);
+#else
 	AddGeneralSocket(drmmode->fd);
 
 	/* Register a wakeup handler to get informed on DRM events */
 	RegisterBlockAndWakeupHandlers((BlockHandlerProcPtr)NoopDDA,
 			drmmode_wakeup_handler, pScrn);
+#endif
 }
 
 void
 drmmode_screen_fini(ScrnInfoPtr pScrn)
 {
+	struct drmmode_rec *drmmode = drmmode_from_scrn(pScrn);
+
+#if HAVE_NOTIFY_FD
+	RemoveNotifyFd(drmmode->fd);
+#else
+	RemoveBlockAndWakeupHandlers((BlockHandlerProcPtr)NoopDDA,
+			drmmode_wakeup_handler, pScrn);
+	RemoveGeneralSocket(drmmode->fd);
+#endif
+
 	drmmode_uevent_fini(pScrn);
 }


### PR DESCRIPTION
Hi,

Here are 2 patches cherry-pick / ported from:
https://cgit.freedesktop.org/xorg/driver/xf86-video-armsoc/

To allow building and using the endless armsoc drv version with xserver 1.19.

Regards,

Hans

p.s.

It would be nice if you could work better with upstream and get these 2 different forks merged. The endless version seems to have a lot of good work done to it. In the mean time the upstream version has gotten Soc specific support for 2 more SoC families.
